### PR TITLE
Use the Ruby URI library to obtain the Salesforce server hostname instead of regex

### DIFF
--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -14,7 +14,6 @@ module SalesforceBulk
       @password = password
       @session_id = nil
       @server_url = nil
-      @instance = nil
       @@API_VERSION = api_version
       @@LOGIN_PATH = "/services/Soap/u/#{@@API_VERSION}"
       @@PATH_PREFIX = "/services/async/#{@@API_VERSION}/"


### PR DESCRIPTION
The upstream gem uses regexes to parse the Salesforce server hostname. It expects custom domains to conform to a pattern like `https://foo.cs24.salesforce.com`. Perhaps there was once a restriction that required the "letter, letter, number from 1 to 99" second level subdomain, but if so, that's no longer that case. We need to support domains like `http://foo.my.salesforce.com`.